### PR TITLE
Throw error on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# CHANGELOG
+
+## 1.0.0
+
+- Forking package from https://github.com/Taiters/sails-hook-dotenv
+- Updating packages:
+  - dotenv `^0.4.0` → `^16.0.0`
+  - mocha `^2.1.0` → `^9.2.0`
+  - sails `^0.11.0` → `^1.5.2`
+- Using new `dotenv.config()` method as opposed to the old `dotenv.load()` method that no longer exists
+- Publishing package under new name `sails-js-hook-dotenv`
+- Clean-up JavaScript in `index.js` and `test/test.js`
+- No longer committing `.env` file. Instead committing `.env.example`
+
+#### 1.0.1
+
+- Adding CHANGELOG
+- Adding check to see if `.env` config actually loads
+  - Add extra customization so that user can decide whether it throws an error on failure or the application continues to spin-up. _See `dotenv.throwOnFailure`_ 
+  - No tests for this functionality yet as there is no configurable way to make the application fail to load dotenv config files
+- Updating README.md

--- a/README.md
+++ b/README.md
@@ -15,9 +15,33 @@ Start sails as you normally do (`sails lift`) and you will be able to access you
 ### Configuration
 
 You can add configuration options for this hook in `config/dotenv.js` by default. Currently, the only option is a boolean: `active`. Setting this to false will disable this hook.
+```js
+module.exports.dotenv = {
+  
+  default: {
+    
+    /**
+     * Setting this to false will disable this hook
+     */
+    active: true,
+
+    /**
+     * Setting this to false will cause the application 
+     * NOT to throw an error if the config fails to load
+     */
+    throwOnFailure: true,
+    
+  }
+  
+}
+```
 
 ### Testing
 
 Copy the `.env.example` file to create a new `.env` file.
 
 Then run `npm run test` in your terminal.
+
+### Changelog
+
+[Changelog](CHANGELOG.md)

--- a/index.js
+++ b/index.js
@@ -1,32 +1,39 @@
-dotenv = require('dotenv');
+dotenv = require('dotenv')
 
-module.exports = function(sails) {
+module.exports = function (sails) {
 
   return {
 
     defaults: {
-
       __configKey__: {
-
-        active: true
-      }
+        active: true,
+        throwOnFailure: true,
+      },
     },
 
-    initialize: function(cb) {
+    initialize: function (cb) {
+      if (!sails.config[this.configKey].active) {
+        sails.log.verbose('Dotenv hook deactivated.')
 
-      if (!sails.config[ this.configKey ].active) {
-
-        sails.log.verbose('Dotenv hook deactivated.');
-        return cb();
-
+        return cb()
       }
 
-      dotenv.config();
+      const result = dotenv.config()
 
-      return cb();
+      // dotenv config failed to load
+      if (result.error) {
 
+        if (sails.config[this.configKey].throwOnFailure) {
+          throw result.error
+        } else {
+          sails.config[this.configKey].active = false
+          sails.log.verbose('Dotenv hook deactivated.')
+        }
+
+        return cb()
+      }
+
+      return cb()
     },
-
-  };
-
-};
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sails-js-hook-dotenv",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Sails.js hook for loading .env files",
     "main": "index.js",
     "keywords": [


### PR DESCRIPTION
- Adding CHANGELOG
- Adding check to see if `.env` config actually loads
  - Add extra customization so that user can decide whether it throws an error on failure or the application continues to spin-up. _See `dotenv.throwOnFailure`_ 
  - No tests for this functionality yet as there is no configurable way to make the application fail to load dotenv config files
- Updating README.md