### PR TITLE
Changing npm install instruction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ using [dotenv](https://github.com/motdotla/dotenv)
 
 ### Installation
 
-`npm install sails-hook-dotenv`
+`npm install sails-js-hook-dotenv`
 
 ### Usage
 


### PR DESCRIPTION
# Changing npm install instruction in readme

## Description

`npm install` instructions were telling you to install the wrong package